### PR TITLE
chore: install moq by aqua.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,7 @@ RUN chown -R vscode:vscode /work \
 
 USER vscode
 
-RUN \
-    go install github.com/matryer/moq@v0.3.4 \
-    && go install github.com/bitnami/wait-for-port@v1.0.7 \
+RUN go install github.com/bitnami/wait-for-port@v1.0.7 \
     ;
 
 COPY --chown=vscode:vscode Makefile go.mod go.sum ./

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -14,3 +14,4 @@ packages:
 - name: jdx/mise@v2024.4.10
 - name: docker/compose@v2.27.0
 - name: golangci/golangci-lint@v1.58.1
+- name: matryer/moq@v0.3.4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker image build process by removing `matryer/moq@v0.3.4` and retaining `wait-for-port@v1.0.7`.
  - Added `matryer/moq@v0.3.4` to the list of packages in `aqua.yaml`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->