### PR TITLE
feat: add healthcheck endpoint

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,8 @@ project_name: gh-ratelimit-metrics-exporter
 
 before:
   hooks:
-    - go mod tidy
     - go generate ./...
+    - go mod tidy
 
 builds:
   - id: gh-ratelimit-metrics-exporter

--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,6 @@ e2e-test:
 	docker stop $(PROJECT_NAME) || true
 	docker run -d --rm -p $(PORT):8080 --env GH_TOKEN=$${GH_TOKEN} --name=$(PROJECT_NAME) ghcr.io/$${GITHUB_REPOSITORY_OWNER}/$(PROJECT_NAME):latest-amd64 && \
 	wait-for localhost:$(PORT) -t 30  && \
+	curl -fsS -X GET http://localhost:$(PORT)/healthz && \
 	curl -fsS -X GET http://localhost:$(PORT)/metrics | promtool check metrics --extended
 	docker stop $(PROJECT_NAME) || true

--- a/app/handler.go
+++ b/app/handler.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func newHTTPHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", healthzHandler)
+	mux.Handle("/metrics", promhttp.Handler())
+	return mux
+}
+
+func healthzHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok\n"))
+}

--- a/app/handler_test.go
+++ b/app/handler_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPHandler_Healthz(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+
+	newHTTPHandler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok\n", rec.Body.String())
+}

--- a/app/main.go
+++ b/app/main.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog"
 	"go.uber.org/dig"
 )
@@ -43,13 +42,10 @@ func main() {
 		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 		defer cancel()
 
-		mux := http.NewServeMux()
-		// TODO: impl health check endpoint.
-		mux.Handle("/metrics", promhttp.Handler())
 		// TODO: enable to change port.
 		server := &http.Server{
 			Addr:    ":8080",
-			Handler: mux,
+			Handler: newHTTPHandler(),
 		}
 		go func() {
 			if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
## Summary
- add /healthz endpoint via shared HTTP handler
- cover /healthz registration with httptest
- check /healthz in e2e-test
- run go generate before go mod tidy in goreleaser hooks

## Validation
- make test
- make e2e-test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health check endpoint that validates container readiness and operational status.

* **Tests**
  * Added health endpoint validation to test coverage and integrated health checks into end-to-end testing workflows.

* **Chores**
  * Reordered build process steps for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->