### PR TITLE
Add missing rate limit metrics

### DIFF
--- a/app/metrics.go
+++ b/app/metrics.go
@@ -48,13 +48,23 @@ var (
 		Name: "github_rate_limit_scim_remaining",
 		Help: "The remaining number of requests to GitHub API",
 	})
+	rateLimitAuditLogRemaining = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "github_rate_limit_audit_log_remaining",
+		Help: "The remaining number of requests to GitHub API",
+	})
+	rateLimitDependencySBOMRemaining = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "github_rate_limit_dependency_sbom_remaining",
+		Help: "The remaining number of requests to GitHub API",
+	})
 )
 
 func initPrometheus() {
 	prometheus.MustRegister(
+		rateLimitAuditLogRemaining,
 		rateLimitCoreRemaining,
 		rateLimitCodeSearchRemaining,
 		rateLimitDependencySnapshotsRemaining,
+		rateLimitDependencySBOMRemaining,
 		rateLimitActionsRunnerRegistrationRemaining,
 		rateLimitCodeScanningUploadRemaining,
 		rateLimitGraphQLRemaining,
@@ -77,14 +87,23 @@ func fetchGitHubRateLimit(rlf RateLimitsFetcher, logger *zerolog.Logger) {
 		logger.Error().Err(err).Msg("Fail to fetch rate limits.")
 		return
 	}
-	rateLimitCoreRemaining.Set(float64(rateLimits.Core.Remaining))
-	rateLimitSearchRemaining.Set(float64(rateLimits.Search.Remaining))
-	rateLimitCodeSearchRemaining.Set(float64(rateLimits.CodeSearch.Remaining))
-	rateLimitGraphQLRemaining.Set(float64(rateLimits.GraphQL.Remaining))
-	rateLimitIntegrationManifestRemaining.Set(float64(rateLimits.IntegrationManifest.Remaining))
-	rateLimitDependencySnapshotsRemaining.Set(float64(rateLimits.DependencySnapshots.Remaining))
-	rateLimitCodeScanningUploadRemaining.Set(float64(rateLimits.CodeScanningUpload.Remaining))
-	rateLimitActionsRunnerRegistrationRemaining.Set(float64(rateLimits.ActionsRunnerRegistration.Remaining))
-	rateLimitSourceImportRemaining.Set(float64(rateLimits.SourceImport.Remaining))
-	rateLimitSCIMRemaining.Set(float64(rateLimits.SCIM.Remaining))
+	setRateLimitRemaining(rateLimitCoreRemaining, rateLimits.Core)
+	setRateLimitRemaining(rateLimitSearchRemaining, rateLimits.Search)
+	setRateLimitRemaining(rateLimitCodeSearchRemaining, rateLimits.CodeSearch)
+	setRateLimitRemaining(rateLimitGraphQLRemaining, rateLimits.GraphQL)
+	setRateLimitRemaining(rateLimitIntegrationManifestRemaining, rateLimits.IntegrationManifest)
+	setRateLimitRemaining(rateLimitDependencySnapshotsRemaining, rateLimits.DependencySnapshots)
+	setRateLimitRemaining(rateLimitCodeScanningUploadRemaining, rateLimits.CodeScanningUpload)
+	setRateLimitRemaining(rateLimitActionsRunnerRegistrationRemaining, rateLimits.ActionsRunnerRegistration)
+	setRateLimitRemaining(rateLimitSourceImportRemaining, rateLimits.SourceImport)
+	setRateLimitRemaining(rateLimitSCIMRemaining, rateLimits.SCIM)
+	setRateLimitRemaining(rateLimitAuditLogRemaining, rateLimits.AuditLog)
+	setRateLimitRemaining(rateLimitDependencySBOMRemaining, rateLimits.DependencySBOM)
+}
+
+func setRateLimitRemaining(gauge prometheus.Gauge, rate *github.Rate) {
+	if rate == nil {
+		return
+	}
+	gauge.Set(float64(rate.Remaining))
 }

--- a/app/metrics_test.go
+++ b/app/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v85/github"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,4 +23,54 @@ func TestFetchGitHubRateLimit_FailToFetch(t *testing.T) {
 	})
 }
 
-// TODO: write test for fetchGitHubRateLimit
+func TestFetchGitHubRateLimit_SetRemainingMetrics(t *testing.T) {
+	rlf := &RateLimitsFetcherMock{
+		FetchFunc: func() (*github.RateLimits, error) {
+			return &github.RateLimits{
+				Core:                      &github.Rate{Remaining: 1},
+				Search:                    &github.Rate{Remaining: 2},
+				CodeSearch:                &github.Rate{Remaining: 3},
+				GraphQL:                   &github.Rate{Remaining: 4},
+				IntegrationManifest:       &github.Rate{Remaining: 5},
+				DependencySnapshots:       &github.Rate{Remaining: 6},
+				CodeScanningUpload:        &github.Rate{Remaining: 7},
+				ActionsRunnerRegistration: &github.Rate{Remaining: 8},
+				SourceImport:              &github.Rate{Remaining: 9},
+				SCIM:                      &github.Rate{Remaining: 10},
+				AuditLog:                  &github.Rate{Remaining: 11},
+				DependencySBOM:            &github.Rate{Remaining: 12},
+			}, nil
+		},
+	}
+
+	logger := NewNullLogger()
+
+	fetchGitHubRateLimit(rlf, logger)
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(rateLimitCoreRemaining))
+	assert.Equal(t, float64(2), testutil.ToFloat64(rateLimitSearchRemaining))
+	assert.Equal(t, float64(3), testutil.ToFloat64(rateLimitCodeSearchRemaining))
+	assert.Equal(t, float64(4), testutil.ToFloat64(rateLimitGraphQLRemaining))
+	assert.Equal(t, float64(5), testutil.ToFloat64(rateLimitIntegrationManifestRemaining))
+	assert.Equal(t, float64(6), testutil.ToFloat64(rateLimitDependencySnapshotsRemaining))
+	assert.Equal(t, float64(7), testutil.ToFloat64(rateLimitCodeScanningUploadRemaining))
+	assert.Equal(t, float64(8), testutil.ToFloat64(rateLimitActionsRunnerRegistrationRemaining))
+	assert.Equal(t, float64(9), testutil.ToFloat64(rateLimitSourceImportRemaining))
+	assert.Equal(t, float64(10), testutil.ToFloat64(rateLimitSCIMRemaining))
+	assert.Equal(t, float64(11), testutil.ToFloat64(rateLimitAuditLogRemaining))
+	assert.Equal(t, float64(12), testutil.ToFloat64(rateLimitDependencySBOMRemaining))
+}
+
+func TestFetchGitHubRateLimit_SkipNilRateLimit(t *testing.T) {
+	rlf := &RateLimitsFetcherMock{
+		FetchFunc: func() (*github.RateLimits, error) {
+			return &github.RateLimits{}, nil
+		},
+	}
+
+	logger := NewNullLogger()
+
+	assert.NotPanics(t, func() {
+		fetchGitHubRateLimit(rlf, logger)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/go-github/v84 v84.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect


### PR DESCRIPTION
Summary:
- Add audit_log and dependency_sbom remaining metrics from go-github/v85 RateLimits.
- Make rate limit metric updates skip nil resources.
- Add coverage for all remaining metrics and nil resources.

Validation:
- make test