### PR TITLE
feat!: use GitHub App client ID for authentication

### DIFF
--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -3,3 +3,5 @@ rules:
     ignore:
       - release.yml
       - .github/workflows/release.yml
+      - _test.yml
+      - .github/workflows/_test.yml

--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -1,11 +1,22 @@
 on:
   workflow_call:
+    inputs:
+      gh-app-client-id:
+        required: false
+        type: string
+    secrets:
+      gh-app-private-key:
+        required: false
 
 permissions: {}
 
 jobs:
   test:
     uses: ./.github/workflows/_test.yml
+    with:
+      gh-app-client-id: ${{ inputs.gh-app-client-id }}
+    secrets:
+      gh-app-private-key: ${{ secrets.gh-app-private-key }}
     permissions:
       contents: read
   lint:

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -1,5 +1,12 @@
 on:
   workflow_call:
+    inputs:
+      gh-app-client-id:
+        required: false
+        type: string
+    secrets:
+      gh-app-private-key:
+        required: false
 
 permissions: {}
 
@@ -27,3 +34,28 @@ jobs:
         run: make e2e-test
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check GitHub App e2e configuration
+        id: github-app-e2e
+        run: |
+          if [[ -z "${GH_APP_CLIENT_ID}" || -z "${GH_PRIVATE_KEY}" ]]; then
+            echo "Skip GitHub App e2e-test because GitHub App secrets are not configured."
+            echo "configured=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "configured=true" >> "${GITHUB_OUTPUT}"
+          fi
+        env:
+          GH_APP_CLIENT_ID: ${{ inputs.gh-app-client-id }}
+          GH_PRIVATE_KEY: ${{ secrets.gh-app-private-key }}
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        if: ${{ steps.github-app-e2e.outputs.configured == 'true' }}
+        with:
+          client-id: ${{ inputs.gh-app-client-id }}
+          private-key: ${{ secrets.gh-app-private-key }}
+      - name: e2e-test-github-app
+        if: ${{ steps.github-app-e2e.outputs.configured == 'true' }}
+        run: make e2e-test
+        env:
+          GH_APP_CLIENT_ID: ${{ inputs.gh-app-client-id }}
+          GH_INSTALLATION_ID: ${{ steps.app-token.outputs.installation-id }}
+          GH_PRIVATE_KEY: ${{ secrets.gh-app-private-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ concurrency:
 jobs:
   ci:
     uses: ./.github/workflows/_ci.yml
+    with:
+      gh-app-client-id: ${{ vars.GH_APP_RELEASE_CLIENT_ID }}
+    secrets:
+      gh-app-private-key: ${{ secrets.GH_APP_RELEASE_PRIVATE_KEY }}
     permissions:
       contents: read
       statuses: write

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,13 @@ test:
 e2e-test: PORT ?= 8080
 e2e-test:
 	docker stop $(PROJECT_NAME) || true
-	docker run -d --rm -p $(PORT):8080 --env GH_TOKEN=$${GH_TOKEN} --name=$(PROJECT_NAME) ghcr.io/$${GITHUB_REPOSITORY_OWNER}/$(PROJECT_NAME):latest-amd64 && \
+	docker run -d --rm -p $(PORT):8080 \
+		--env GH_TOKEN=$${GH_TOKEN} \
+		--env GH_APP_CLIENT_ID=$${GH_APP_CLIENT_ID} \
+		--env GH_INSTALLATION_ID=$${GH_INSTALLATION_ID} \
+		--env GH_PRIVATE_KEY="$${GH_PRIVATE_KEY}" \
+		--name=$(PROJECT_NAME) \
+		ghcr.io/$${GITHUB_REPOSITORY_OWNER}/$(PROJECT_NAME):latest-amd64 && \
 	wait-for localhost:$(PORT) -t 30  && \
 	curl -fsS -X GET http://localhost:$(PORT)/healthz && \
 	curl -fsS -X GET http://localhost:$(PORT)/metrics | promtool check metrics --extended

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,0 @@
-# TODO
-
-- Add an e2e test path for GitHub App authentication.

--- a/app/github_app.go
+++ b/app/github_app.go
@@ -14,26 +14,22 @@ import (
 
 // newClientWithGitHubApp creates a new GitHub client with GitHub App.
 func newClientWithGitHubApp(logger *zerolog.Logger) *github.Client {
-	ghAppID := os.Getenv("GH_APP_ID")
+	ghAppClientID := os.Getenv("GH_APP_CLIENT_ID")
 	ghInstallationID := os.Getenv("GH_INSTALLATION_ID")
 	ghPrivateKey := os.Getenv("GH_PRIVATE_KEY")
 
-	if ghAppID == "" || ghInstallationID == "" || ghPrivateKey == "" {
-		logger.Debug().Msg("Neighter GH_APP_ID nor GH_INSTALLATION_ID nor GH_PRIVATE_KEY is set. Skip generating a new GitHub client with GitHub App.")
+	if ghAppClientID == "" || ghInstallationID == "" || ghPrivateKey == "" {
+		logger.Debug().Msg("Neither GH_APP_CLIENT_ID nor GH_INSTALLATION_ID nor GH_PRIVATE_KEY is set. Skip generating a new GitHub client with GitHub App.")
 		return nil
 	}
 
-	ghAppIDInt64, err := strconv.ParseInt(ghAppID, 10, 64)
-	if err != nil {
-		logger.Error().Msg("Failed to parse GH_APP_ID as integer.")
-		return nil
-	}
 	ghInstallationIDInt64, err := strconv.ParseInt(ghInstallationID, 10, 64)
 	if err != nil {
 		logger.Error().Msg("Failed to parse GH_INSTALLATION_ID as integer.")
 		return nil
 	}
-	client, err := newGitHubAppHTTPClient(ghAppIDInt64, ghInstallationIDInt64, []byte(ghPrivateKey))
+
+	client, err := newGitHubAppHTTPClient(ghAppClientID, ghInstallationIDInt64, []byte(ghPrivateKey))
 	if err != nil {
 		logger.Error().Msg("Failed to new HTTP client with GitHub App.")
 		return nil
@@ -42,8 +38,8 @@ func newClientWithGitHubApp(logger *zerolog.Logger) *github.Client {
 	return github.NewClient(client)
 }
 
-func newGitHubAppHTTPClient(appID, installationID int64, privateKey []byte) (*http.Client, error) {
-	appTokenSource, err := githubauth.NewApplicationTokenSource(appID, privateKey)
+func newGitHubAppHTTPClient(appClientID string, installationID int64, privateKey []byte) (*http.Client, error) {
+	appTokenSource, err := githubauth.NewApplicationTokenSource(appClientID, privateKey)
 	if err != nil {
 		return nil, err
 	}

--- a/app/github_app_test.go
+++ b/app/github_app_test.go
@@ -26,63 +26,56 @@ func TestNewClientWithGitHubApp(t *testing.T) {
 
 	tests := []struct {
 		testName       string
-		appID          string
+		appClientID    string
 		installationID string
 		privateKey     string
 		expectNil      bool
 	}{
 		{
 			testName:       "No env at all",
-			appID:          "",
+			appClientID:    "",
 			installationID: "",
 			privateKey:     "",
 			expectNil:      true,
 		},
 		{
-			testName:       "Lack of app_id",
-			appID:          "",
-			installationID: "1008",
-			privateKey:     pemDataString,
-			expectNil:      true,
-		},
-		{
-			testName:       "Not integer app_id",
-			appID:          "abc",
+			testName:       "Lack of client_id",
+			appClientID:    "",
 			installationID: "1008",
 			privateKey:     pemDataString,
 			expectNil:      true,
 		},
 		{
 			testName:       "Lack of installation_id",
-			appID:          "100",
+			appClientID:    "Iv1.0123456789abcdef",
 			installationID: "",
 			privateKey:     pemDataString,
 			expectNil:      true,
 		},
 		{
 			testName:       "Not integer installation_id",
-			appID:          "100",
+			appClientID:    "Iv1.0123456789abcdef",
 			installationID: "def",
 			privateKey:     pemDataString,
 			expectNil:      true,
 		},
 		{
 			testName:       "Lack of private_key",
-			appID:          "100",
+			appClientID:    "Iv1.0123456789abcdef",
 			installationID: "1008",
 			privateKey:     "",
 			expectNil:      true,
 		},
 		{
 			testName:       "Broken private key",
-			appID:          "100",
+			appClientID:    "Iv1.0123456789abcdef",
 			installationID: "1008",
 			privateKey:     "foobarbaz",
 			expectNil:      true,
 		},
 		{
 			testName:       "Ok",
-			appID:          "100",
+			appClientID:    "Iv1.0123456789abcdef",
 			installationID: "1008",
 			privateKey:     pemDataString,
 			expectNil:      false,
@@ -93,7 +86,7 @@ func TestNewClientWithGitHubApp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			t.Setenv("GH_APP_ID", tt.appID)
+			t.Setenv("GH_APP_CLIENT_ID", tt.appClientID)
 			t.Setenv("GH_INSTALLATION_ID", tt.installationID)
 			t.Setenv("GH_PRIVATE_KEY", tt.privateKey)
 
@@ -115,7 +108,7 @@ func TestNewGitHubAppHTTPClientUsesEmptyPermissions(t *testing.T) {
 		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
 	})
 
-	client, err := newGitHubAppHTTPClient(100, 1008, pemData)
+	client, err := newGitHubAppHTTPClient("Iv1.0123456789abcdef", 1008, pemData)
 	require.NoError(t, err)
 	require.NotNil(t, client)
 


### PR DESCRIPTION
## Summary
- replace GitHub App auth configuration from numeric app ID to client ID
- add reusable workflow secret/input passing for GitHub App e2e coverage
- derive the installation ID in CI via actions/create-github-app-token and pass it into the container
- remove the tracked TODO.md file

## Breaking Change
- GH_APP_ID is replaced by GH_APP_CLIENT_ID for GitHub App authentication.

## Validation
- make test
- actionlint -shellcheck= .github/workflows/ci.yml .github/workflows/_ci.yml .github/workflows/_test.yml
- git diff --check --cached