### PR TITLE
ci: require GitHub App e2e configuration

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -2,11 +2,11 @@ on:
   workflow_call:
     inputs:
       gh-app-client-id:
-        required: false
+        required: true
         type: string
     secrets:
       gh-app-private-key:
-        required: false
+        required: true
 
 permissions: {}
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -2,11 +2,11 @@ on:
   workflow_call:
     inputs:
       gh-app-client-id:
-        required: false
+        required: true
         type: string
     secrets:
       gh-app-private-key:
-        required: false
+        required: true
 
 permissions: {}
 
@@ -34,26 +34,12 @@ jobs:
         run: make e2e-test
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: check GitHub App e2e configuration
-        id: github-app-e2e
-        run: |
-          if [[ -z "${GH_APP_CLIENT_ID}" || -z "${GH_PRIVATE_KEY}" ]]; then
-            echo "Skip GitHub App e2e-test because GitHub App secrets are not configured."
-            echo "configured=false" >> "${GITHUB_OUTPUT}"
-          else
-            echo "configured=true" >> "${GITHUB_OUTPUT}"
-          fi
-        env:
-          GH_APP_CLIENT_ID: ${{ inputs.gh-app-client-id }}
-          GH_PRIVATE_KEY: ${{ secrets.gh-app-private-key }}
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
-        if: ${{ steps.github-app-e2e.outputs.configured == 'true' }}
         with:
           client-id: ${{ inputs.gh-app-client-id }}
           private-key: ${{ secrets.gh-app-private-key }}
       - name: e2e-test-github-app
-        if: ${{ steps.github-app-e2e.outputs.configured == 'true' }}
         run: make e2e-test
         env:
           GH_APP_CLIENT_ID: ${{ inputs.gh-app-client-id }}

--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,6 @@ e2e-test:
 		ghcr.io/$${GITHUB_REPOSITORY_OWNER}/$(PROJECT_NAME):latest-amd64 && \
 	wait-for localhost:$(PORT) -t 30  && \
 	curl -fsS -X GET http://localhost:$(PORT)/healthz && \
-	curl -fsS -X GET http://localhost:$(PORT)/metrics | promtool check metrics --extended
+	curl -fsS -X GET http://localhost:$(PORT)/metrics | promtool check metrics --extended && \
+	curl -fsS -X GET http://localhost:$(PORT)/metrics
 	docker stop $(PROJECT_NAME) || true


### PR DESCRIPTION
## Summary
- make GitHub App e2e workflow inputs and secrets required
- always run the GitHub App e2e path without a conditional skip
- fetch /metrics normally after promtool validation in e2e

## Validation
- make test
- actionlint -shellcheck= .github/workflows/ci.yml .github/workflows/_ci.yml .github/workflows/_test.yml
- zizmor --config .github/linters/zizmor.yaml .github/workflows
- git diff --check