### PR TITLE
Revert "chore(deps): update go module directive to v1.26.3"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/air-hand/gh-ratelimit-metrics-exporter
 
-go 1.26.3
+go 1.26.2
 
 require (
 	github.com/cockroachdb/errors v1.13.0


### PR DESCRIPTION
Reverts air-hand-org/gh-ratelimit-metrics-exporter#66