### PR TITLE
Fix debug launch configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,10 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/app"
+            "program": "${workspaceFolder}/cmd/server",
+            "env": {
+                "GITHUB_TOKEN": "dummy"
+            }
         }
     ]
 }

--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,15 @@
+[
+  {
+    "label": "Run server",
+    "adapter": "Delve",
+    "request": "launch",
+    "mode": "debug",
+    "program": "./cmd/server",
+    "cwd": "${ZED_WORKTREE_ROOT}",
+    "env": {
+      "GITHUB_TOKEN": "dummy"
+    },
+    "args": [],
+    "buildFlags": []
+  }
+]


### PR DESCRIPTION
## Summary
- Add a Zed Delve debug configuration for the server package
- Update the VS Code launch target from the removed app path to cmd/server
- Set dummy GITHUB_TOKEN values for local debug sessions

## Validation
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment debugging configurations across multiple editors to improve local development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->